### PR TITLE
[EN-1416] Add RPC services to Juwai-Mysql box

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,8 +1,12 @@
 ---
 # handlers file for consul
+- name: supervisord update consul
+  command: supervisorctl update
+  notify: supervisord restart consul
+  when: consul_supervisor_enabled
+
 - name: supervisord restart consul
   supervisorctl:
     name: consul
     state: restarted
   when: consul_supervisor_enabled
-  ignore_errors: true

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -8,7 +8,7 @@
   with_items:
     - common.json
     - connection.json
-  notify: supervisord restart consul
+  notify: supervisord update consul
 
 - name: add server configuration
   template:
@@ -17,7 +17,7 @@
     owner: "{{ consul_user }}"
     group: "{{ consul_group }}"
   when: consul_server
-  notify: supervisord restart consul
+  notify: supervisord update consul
 
 - name: install the supervisord config script
   template:
@@ -27,7 +27,7 @@
     group: root
     mode: 0644
   when: consul_supervisor_enabled
-  notify: supervisord restart consul
+  notify: supervisord update consul
 
 - name: add services configuration
   template:
@@ -35,4 +35,4 @@
     dest: "{{ consul_conf_dir }}/rpc_services.json"
     owner: "{{ consul_user }}"
     group: "{{ consul_group }}"
-  notify: supervisord restart consul
+  notify: supervisord update consul


### PR DESCRIPTION
http://jira.juwai.com/browse/EN-1416

Calling update makes sure supervisord has read the config file. If trying to restart the daemon before reading the config file supervisord can shut down. I don't know why this happens. It's probably Ansible related and not supervisord's fault. Also, if config is not read, you can not start the daemon.

@imlazyone @agirivera please review
