### PR TITLE
Promote `item.tags` as a full-fledged yaml array

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,13 +64,11 @@ For example, install `time_service` and bind to `8081` port (also add `tags` and
 
 ```
 rpc_services:
-  - {
-    name: time_service,
-    port: 8081,
-    tags: "['rpc']",
-    check: zerorpc --connect tcp://127.0.0.1:8081 --timeout 1 _zerorpc_ping,
+  - name: time_service
+    port: 8081
+    tags: ["rpc"]
+    check: "zerorpc --connect tcp://127.0.0.1:8081 --timeout 1 _zerorpc_ping"
     interval: 60s
-  }
 ```
 
 Dependencies

--- a/templates/rpc_services.json.j2
+++ b/templates/rpc_services.json.j2
@@ -3,7 +3,7 @@
   {%- for item in rpc_services %}
     {
       "name": "{{ item.name }}",
-      "tags": {{ item.tags }},
+      "tags": {{ item.tags | to_json }},
       "port": {{ item.port }},
       "check": {
         "script": "{{ item.check }}",


### PR DESCRIPTION
## Summary of changes
- Promotes `item.tags` as a full-fledged yaml array to avoid json quoting issues
- Updates documentation to reflect change

/fyi: @juwai/platform-all Please review. Thanks.
