### PR TITLE
Set default version 1.9.4 and make adjustments for upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.galaxy_install_info

--- a/README.md
+++ b/README.md
@@ -33,13 +33,19 @@ Default is `consul:consul`.
 
 ## consul_version
 
-Default consul version is `0.5.0`.
+Default consul version is `1.9.4`.
 
-## consul_url, consul_ui_url
+## consul_url
 
-URL to download consul and consul ui packages.
+URL to download consul package.
 
-## consul_dir, consul_conf_dir, consul_data_dir, consul_log_dir, consul_ui_dir
+## consul_ui
+
+Enable UI or not.
+
+Default is `true`.
+
+## consul_dir, consul_conf_dir, consul_data_dir, consul_log_dir
 
 Directories for consul.
 
@@ -48,7 +54,6 @@ Directories for consul.
 ├── bin
 ├── consul.d
 ├── data
-├── dist
 └── logs
 ```
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -41,7 +41,7 @@ consul_retry_max: 10
 consul_server_name: "{{ inventory_hostname }}"
 consul_node_name: "{{ inventory_hostname }}"
 
-consul_ui: true
+consul_ui: "{{ json_true }}"
 
 rpc_services:
   - {

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,20 +3,18 @@
 consul_server: true
 consul_supervisor_enabled: true
 
-consul_user: consul
-consul_group: consul
+consul_user: "consul"
+consul_group: "consul"
 
-consul_version: 0.5.0
-consul_url: https://releases.hashicorp.com/consul/{{ consul_version }}/consul_{{ consul_version }}
-consul_ui_url: https://releases.hashicorp.com/consul/{{ consul_version }}/consul_{{ consul_version }}_web_ui.zip
+consul_version: "1.9.4"
+consul_url: "https://releases.hashicorp.com/consul/{{ consul_version }}/consul_{{ consul_version }}"
 
-consul_dir: /home/{{ consul_user }}/consul_{{ consul_version }}
+consul_dir: "/home/{{ consul_user }}/consul_{{ consul_version }}"
 consul_conf_dir: "{{ consul_dir }}/consul.d"
 consul_data_dir: "{{ consul_dir }}/data"
 consul_log_dir: "{{ consul_dir }}/logs"
-consul_ui_dir: "{{ consul_dir }}/dist"
 
-consul_log_level: info
+consul_log_level: "info"
 consul_bootstrap_expect: 1
 
 # make sure these get interpreted as strings not booleans
@@ -24,8 +22,8 @@ json_true: "true"
 json_false: "false"
 
 # config values from http://www.consul.io/docs/agent/options.html
-consul_datacenter: dc1
-consul_client_address: 0.0.0.0
+consul_datacenter: "dc1"
+consul_client_address: "0.0.0.0"
 consul_advertise_address: "{{ ansible_ssh_host }}"
 consul_bind_address: "{{ ansible_ssh_host }}"
 
@@ -37,24 +35,26 @@ consul_leave_on_terminate: "{{ json_false }}"
 consul_cluster_addresses:
   - "{{ ansible_ssh_host }}"
 
-consul_retry_interval: 30s
+consul_retry_interval: "30s"
 consul_retry_max: 10
 
 consul_server_name: "{{ inventory_hostname }}"
 consul_node_name: "{{ inventory_hostname }}"
 
+consul_ui: true
+
 rpc_services:
   - {
-    name: time_service,
+    name: "time_service",
     port: 8081,
     tags: '["rpc"]',
     check: "zerorpc --connect tcp://127.0.0.1:8081 --timeout 1 _zerorpc_ping",
-    interval: 60s
+    interval: "60s"
   }
   - {
-    name: place_service,
+    name: "place_service",
     port: 8082,
     tags: '["rpc"]',
     check: "zerorpc --connect tcp://127.0.0.1:8082 --timeout 1 _zerorpc_ping",
-    interval: 60s
+    interval: "60s"
   }

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -13,12 +13,6 @@
     timeout: 60
   when: ansible_userspace_bits == "32"
 
-- get_url:
-    url: "{{ consul_ui_url }}"
-    dest: /tmp/consul_ui_{{ consul_version }}.zip
-    validate_certs: no
-  when: consul_server == true
-
 - group: name={{ consul_group }}
 - user: name={{ consul_user }} group={{ consul_group }}
 
@@ -35,12 +29,6 @@
   command: "unzip /tmp/consul_{{ consul_version }}.zip -d {{ consul_dir }}/bin"
   args:
     creates: "{{ consul_dir }}/bin/consul"
-
-- name: unpack the ui archive
-  command: "unzip /tmp/consul_ui_{{ consul_version }}.zip -d {{ consul_dir }}"
-  args:
-    creates: "{{ consul_ui_dir }}"
-  when: consul_server == true
 
 - name: make link to consul folder
   file: src={{ consul_dir }} dest=/opt/consul state=link

--- a/templates/connection.json.j2
+++ b/templates/connection.json.j2
@@ -4,7 +4,7 @@
   "bind_addr": "{{ consul_bind_address }}",
   "ports": {
     "http": {{ consul_http_port }},
-    "rpc": {{ consul_rpc_port }},
+    "grpc": {{ consul_rpc_port }},
     "server": {{ consul_server_port }}
   }
 }

--- a/templates/rpc_services.json.j2
+++ b/templates/rpc_services.json.j2
@@ -6,7 +6,7 @@
       "tags": {{ item.tags | to_json }},
       "port": {{ item.port }},
       "check": {
-        "script": "{{ item.check }}",
+        "args": ["sh", "-c", "{{ item.check }}"],
         "interval": "{{ item.interval }}"
       }
     }{% if not loop.last %},{% endif -%}

--- a/templates/server.json.j2
+++ b/templates/server.json.j2
@@ -1,6 +1,9 @@
 {
   "server": true,
   "server_name": "{{ consul_server_name }}",
-  "ui_dir": "{{ consul_ui_dir }}",
-  "bootstrap_expect": {{ consul_bootstrap_expect }}
+  "bootstrap_expect": {{ consul_bootstrap_expect }},
+  "enable_script_checks": true,
+  "ui_config": {
+    "enabled": {{ consul_ui }}
+  }
 }


### PR DESCRIPTION
## Summary of changes

- Set default Consul version to 1.9.4
- Remove tasks for UI as it is now built into the executable
- Make configuration changes to work with newer versions

## How to Test

Replace role requirements to pull this version:

```yaml
- src: git@github.com:tjoelsson/ansible-role-consul
  scm: git
  name: juwai.consul
  version: 1fc48c3
```

Run your playbook